### PR TITLE
Fix download link for libmikmod

### DIFF
--- a/scripts/libmikmod.sh
+++ b/scripts/libmikmod.sh
@@ -1,4 +1,4 @@
-download_and_extract http://downloads.sourceforge.net/project/mikmod/outdated_versions/libmikmod/3.2.0/libmikmod-3.2.0.tar.gz libmikmod-3.2.0
+download_and_extract http://downloads.sourceforge.net/project/mikmod/outdated_versions/libmikmod/3.2.0/libmikmod-3.2.0-DONTUSE.tar.gz libmikmod-3.2.0
 apply_patch libmikmod-3.2.0-PSP
 aclocal --force
 libtoolize --force


### PR DESCRIPTION
libmikmod could not be downloaded: caused libmikmod itself and SDL_mixer to fail compilation
