### PR TITLE
smpeg-psp migration from google code to github

### DIFF
--- a/scripts/smpeg-psp.sh
+++ b/scripts/smpeg-psp.sh
@@ -1,8 +1,5 @@
-if test ! -d "smpeg-psp"; then
-  svn checkout http://smpeg-psp.googlecode.com/svn/trunk smpeg-psp
-else
-  svn update smpeg-psp
-fi
+wget --continue --no-check-certificate https://github.com/fungos/smpeg-psp/tarball/master -O smpeg-psp.tar.gz
+rm -Rf smpeg-psp && mkdir smpeg-psp && tar --strip-components=1 --directory=smpeg-psp -xvzf smpeg-psp.tar.gz
 cd smpeg-psp
 sed -i -e "s/static __inline__ Uint16 SDL_Swap16(Uint16 x)/static __inline__ Uint16 Disable_SDL_Swap16(Uint16 x)/" audio/*.cpp || { exit 1; }
 run_make -j `num_cpus`


### PR DESCRIPTION
Google code is closing and all projects are being exported to github, this fix smpeg-psp script to find the new repository.