### PR TITLE
Fixed libtool version mismatch error when compiling SDL_gfx

### DIFF
--- a/scripts/SDL_gfx.sh
+++ b/scripts/SDL_gfx.sh
@@ -1,10 +1,7 @@
 test_deps_install SDL
 download_and_extract http://sourceforge.net/projects/sdlgfx/files/SDL_gfx-2.0.23.tar.gz SDL_gfx-2.0.23
-autoreconf --force --install
 apply_patch SDL_gfx-2.0.23-PSP
-aclocal --force
-autoconf --force
-automake --add-missing
+autoreconf --force --install
 run_configure --prefix=$(psp-config --psp-prefix) --host=psp --disable-mmx --disable-shared
 run_make
 #PNG_CFLAGS="-I$PSPDEV/psp/include" PNG_LIBS="-L$PSPDEV/psp/lib -lpng -lz" AR=psp-ar run_autogen_build --with-sdl-prefix=$(psp-config --psp-prefix) --host=psp --disable-mmx --disable-shared

--- a/scripts/SDL_gfx.sh
+++ b/scripts/SDL_gfx.sh
@@ -1,5 +1,6 @@
 test_deps_install SDL
 download_and_extract http://sourceforge.net/projects/sdlgfx/files/SDL_gfx-2.0.23.tar.gz SDL_gfx-2.0.23
+autoreconf --force --install
 apply_patch SDL_gfx-2.0.23-PSP
 aclocal --force
 autoconf --force


### PR DESCRIPTION
I had some issues during compilation of SDL_gfx:
```
libtool: Version mismatch error.  This is libtool 2.4.2, but the
libtool: definition of this LT_INIT comes from libtool 2.4.6.
libtool: You should recreate aclocal.m4 with macros from libtool 2.4.2
libtool: and run autoconf again.
```
This should fix it.