### PR TITLE
Fixed build & portability issues

### DIFF
--- a/depends/check-libtool.sh
+++ b/depends/check-libtool.sh
@@ -2,4 +2,4 @@
 # check-libtool.sh by Dan Peori (danpeori@oopo.net)
 
  ## Check for libtool.
- libtool --version
+ ${LIBTOOLIZE:-libtoolize} --version

--- a/libraries.sh
+++ b/libraries.sh
@@ -4,6 +4,14 @@
  unset CC
  unset CXX
 
+ ## Set executable name for libtoolize
+ if [ "$(uname)" == "Darwin" ]; then
+     LIBTOOLIZE=glibtoolize
+ else
+     LIBTOOLIZE=libtoolize
+ fi
+ export LIBTOOLIZE
+
  ## Enter the psplibraries directory.
  cd "`dirname $0`" || { echo "ERROR: Could not enter the psplibraries directory."; exit 1; }
 

--- a/patches/squirrel-3.0.7.patch
+++ b/patches/squirrel-3.0.7.patch
@@ -17,13 +17,13 @@ index 911a16b..81c2561 100755
 -	
 -	
 -sq32:
--	g++ -O2 -s -fno-exceptions -fno-rtti -o $(OUT) $(SRCS) $(INCZ) $(LIBZ) $(LIB)
+-	g++ -O2 -fno-exceptions -fno-rtti -o $(OUT) $(SRCS) $(INCZ) $(LIBZ) $(LIB)
 -
 -sqprof:
 -	g++ -O2 -pg -fno-exceptions -fno-rtti -pie -gstabs -g3 -o $(OUT) $(SRCS) $(INCZ) $(LIBZ) $(LIB)
 -	
 -sq64:
--	g++ -O2 -s -m64 -fno-exceptions -fno-rtti -D_SQ64 -o $(OUT) $(SRCS) $(INCZ) $(LIBZ) $(LIB)
+-	g++ -O2 -m64 -fno-exceptions -fno-rtti -D_SQ64 -o $(OUT) $(SRCS) $(INCZ) $(LIBZ) $(LIB)
 +SQUIRREL= ..
 +
 +
@@ -38,13 +38,13 @@ index 911a16b..81c2561 100755
 +	
 +	
 +sq32:
-+	$(CXX) -O2 -s -fno-exceptions -fno-rtti -o $(OUT) $(SRCS) $(INCZ) $(LIBZ) $(LIB)
++	$(CXX) -O2 -fno-exceptions -fno-rtti -o $(OUT) $(SRCS) $(INCZ) $(LIBZ) $(LIB)
 +
 +sqprof:
 +	$(CXX) -O2 -pg -fno-exceptions -fno-rtti -pie -gstabs -g3 -o $(OUT) $(SRCS) $(INCZ) $(LIBZ) $(LIB)
 +	
 +sq64:
-+	$(CXX) -O2 -s -m64 -fno-exceptions -fno-rtti -D_SQ64 -o $(OUT) $(SRCS) $(INCZ) $(LIBZ) $(LIB)
++	$(CXX) -O2 -m64 -fno-exceptions -fno-rtti -D_SQ64 -o $(OUT) $(SRCS) $(INCZ) $(LIBZ) $(LIB)
 diff --git a/sqstdlib/Makefile b/sqstdlib/Makefile
 index 10f6384..39b075e 100755
 --- a/sqstdlib/Makefile

--- a/scripts/libmikmod.sh
+++ b/scripts/libmikmod.sh
@@ -10,5 +10,5 @@ aclocal --force
 autoconf --force
 autoheader --force
 automake --add-missing
-run_configure --disable-esd
+run_configure --disable-esd --enable-osx=no
 run_make -j `num_cpus`

--- a/scripts/openal.sh
+++ b/scripts/openal.sh
@@ -11,7 +11,7 @@ download_and_extract http://kcat.strangesoft.net/openal-releases/openal-soft-$OP
 sed -i -e "s/memory\.h/string.h/" Alc/*.c Alc/backends/*.c || { exit 1; }
 
 ## Run cmake
-psp-cmake -D CMAKE_INSTALL_PREFIX=$(psp-config --psp-prefix) . || { exit 1; }
+psp-cmake -D CMAKE_INSTALL_PREFIX=$(psp-config --psp-prefix) -D UTILS=OFF . || { exit 1; }
 
 ## Compile and Install
 run_make -j `num_cpus`

--- a/scripts/squirrel.sh
+++ b/scripts/squirrel.sh
@@ -1,5 +1,5 @@
-download_and_extract http://squirrel.googlecode.com/files/squirrel_3_0_2_stable.tar.gz SQUIRREL3
-apply_patch squirrel-3.0.2
+download_and_extract http://sourceforge.net/projects/squirrel/files/squirrel_3_0_7_stable.tar.gz SQUIRREL3
+apply_patch squirrel-3.0.7
 AR="psp-ar" CC="psp-gcc" CXX="psp-g++" LIBS="-lc -lpspuser" make -j `num_cpus` -C squirrel sq32
 AR="psp-ar" CC="psp-gcc" CXX="psp-g++" LIBS="-lc -lpspuser" make -j `num_cpus` -C sqstdlib sq32
 cp -v lib/*.a $(psp-config --psp-prefix)/lib


### PR DESCRIPTION
- Use $LIBTOOLIZE for better OS X compatibility. With some trivial changes to psp-ports/freetype, it compiles on OS X now, please also check out my pull request there.
- Turned off the utility option in OpenAL build script, that is, makehrtf & openal-info. I could not tell any use of these naked MIPS ELFs, except that they lead to a build failure.
- Upgrade squirrel from 3.0.2 to 3.0.7, use sourceforge.net as download source because googlecode.com has various connection issues in mainland China :(
- libmikmod's configure script will enable the osx driver on Darwin system by default, this will lead to compiling errors when compiling with psp-gcc on Mac OS X.