### PR TITLE
Fix SDL_image 1.11+ build

### DIFF
--- a/scripts/SDL_image.sh
+++ b/scripts/SDL_image.sh
@@ -2,5 +2,5 @@ test_deps_install SDL libpng jpeg
 
 download_and_extract http://www.libsdl.org/projects/SDL_image/release/SDL_image-1.2.12.tar.gz SDL_image-1.2.12
 apply_patch SDL_image-1.2.12-PSP
-LDFLAGS="-lpspirkeyb" run_autogen_build --with-sdl-prefix=$(psp-config --psp-prefix)
+LDFLAGS="-lpspirkeyb" run_autogen_build --disable-webp --with-sdl-prefix=$(psp-config --psp-prefix)
 


### PR DESCRIPTION
(webp is not shipped with psplibraries but required by default)