### PR TITLE
Force ignoring case (default on nix, not default on Mac)

### DIFF
--- a/libraries.sh
+++ b/libraries.sh
@@ -27,7 +27,7 @@
  # Else, run the all build scripts.
  else
      buildall=1
-     list="$(ls -1 $basepath/scripts/*.sh | sed -e "s/.*\///" -e "s/\..*//" | sort)"
+     list="$(ls -1 $basepath/scripts/*.sh | sed -e "s/.*\///" -e "s/\..*//" | sort -f)"
  fi
 
  faillist=""


### PR DESCRIPTION
SDL* libraries depend on pspirkeyb.

On Macs sorts by default are case sensitive, causing SDL to appear first in the list:
```
$ echo $(ls -1 $basepath/scripts/*.sh | sed -e "s/.*\///" -e "s/\..*//" | sort)
SDL SDL_gfx SDL_image SDL_mixer SDL_ttf angelscript bzip2 cmake-toolchain-script expat freetype jpeg libbulletml libmad libmikmod libogg libpng libpspvram libtremor libvorbis libyaml lua openal opentri pixman pspgl pspirkeyb pthreads-emb smpeg-psp sqlite squirrel zlib zziplib
```

With SDL being compiled first, it leads to errors such as:
```
./src/video/psp/SDL_pspevents.c:42:23: fatal error: pspirkeyb.h: No such file or directory
 #include <pspirkeyb.h>
```

Using `sort -f` (ignore-case) makes the sort work consistently across Macs and nix systems.
```
$ echo $(ls -1 $basepath/scripts/*.sh | sed -e "s/.*\///" -e "s/\..*//" | sort -f)
angelscript bzip2 cmake-toolchain-script expat freetype jpeg libbulletml libmad libmikmod libogg libpng libpspvram libtremor libvorbis libyaml lua openal opentri pixman pspgl pspirkeyb pthreads-emb SDL SDL_gfx SDL_image SDL_mixer SDL_ttf smpeg-psp sqlite squirrel zlib zziplib
```
