### PR TITLE
Updates bzip2 download link and adds patch to fix smpeg-psp compilation.

### DIFF
--- a/patches/smpeg-psp.patch
+++ b/patches/smpeg-psp.patch
@@ -1,0 +1,33 @@
+--- smpeg-psp/audio/hufftable.cpp	2019-07-11 21:25:52.983004746 -0400
++++ smpeg-psp-fix/audio/hufftable.cpp	2019-07-10 22:26:05.909736000 -0400
+@@ -9,6 +9,7 @@
+ #include "config.h"
+ #endif
+ 
++#include <climits>
+ #include "MPEGaudio.h"
+ 
+ static const unsigned int
+@@ -550,11 +551,11 @@
+ 
+ const HUFFMANCODETABLE MPEGaudio::ht[HTN]=
+ {
+-  { 0, 0-1, 0-1, 0,  0, htd33},
++  { 0, UINT_MAX, UINT_MAX, 0,  0, htd33},
+   { 1, 2-1, 2-1, 0,  7,htd01},
+   { 2, 3-1, 3-1, 0, 17,htd02},
+   { 3, 3-1, 3-1, 0, 17,htd03},
+-  { 4, 0-1, 0-1, 0,  0, htd33},
++  { 4, UINT_MAX, UINT_MAX, 0,  0, htd33},
+   { 5, 4-1, 4-1, 0, 31,htd05},
+   { 6, 4-1, 4-1, 0, 31,htd06},
+   { 7, 6-1, 6-1, 0, 71,htd07},
+@@ -564,7 +565,7 @@
+   {11, 8-1, 8-1, 0,127,htd11},
+   {12, 8-1, 8-1, 0,127,htd12},
+   {13,16-1,16-1, 0,511,htd13},
+-  {14, 0-1, 0-1, 0,  0, htd33},
++  {14, UINT_MAX, UINT_MAX, 0,  0, htd33},
+   {15,16-1,16-1, 0,511,htd15},
+   {16,16-1,16-1, 1,511,htd16},
+   {17,16-1,16-1, 2,511,htd16},

--- a/scripts/bzip2.sh
+++ b/scripts/bzip2.sh
@@ -1,5 +1,5 @@
 BZIP2_VERSION=1.0.6
 
-download_and_extract http://www.bzip.org/$BZIP2_VERSION/bzip2-$BZIP2_VERSION.tar.gz bzip2-$BZIP2_VERSION
+download_and_extract ftp://sourceware.org/pub/bzip2/bzip2-$BZIP2_VERSION.tar.gz bzip2-$BZIP2_VERSION
 apply_patch bzip2-$BZIP2_VERSION-PSP
 run_make -j `num_cpus`

--- a/scripts/smpeg-psp.sh
+++ b/scripts/smpeg-psp.sh
@@ -1,7 +1,7 @@
 wget --continue --no-check-certificate https://github.com/fungos/smpeg-psp/tarball/master -O smpeg-psp.tar.gz
 rm -Rf smpeg-psp && mkdir smpeg-psp && tar --strip-components=1 --directory=smpeg-psp -xvzf smpeg-psp.tar.gz
 cd smpeg-psp
-apply_patch smpeg-psp.patch
+apply_patch smpeg-psp
 sed -i -e "s/static __inline__ Uint16 SDL_Swap16(Uint16 x)/static __inline__ Uint16 Disable_SDL_Swap16(Uint16 x)/" audio/*.cpp || { exit 1; }
 run_make -j `num_cpus`
 

--- a/scripts/smpeg-psp.sh
+++ b/scripts/smpeg-psp.sh
@@ -1,6 +1,7 @@
 wget --continue --no-check-certificate https://github.com/fungos/smpeg-psp/tarball/master -O smpeg-psp.tar.gz
 rm -Rf smpeg-psp && mkdir smpeg-psp && tar --strip-components=1 --directory=smpeg-psp -xvzf smpeg-psp.tar.gz
 cd smpeg-psp
+apply_patch smpeg-psp.patch
 sed -i -e "s/static __inline__ Uint16 SDL_Swap16(Uint16 x)/static __inline__ Uint16 Disable_SDL_Swap16(Uint16 x)/" audio/*.cpp || { exit 1; }
 run_make -j `num_cpus`
 


### PR DESCRIPTION
bzip.org no longer hosts the source archives, sourceware.org used instead. hufftable.cpp in smpeg-psp would not compile on Ubuntu 19.04.