### PR TITLE
Add zziplib check

### DIFF
--- a/depends/check-zziplib.sh
+++ b/depends/check-zziplib.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+ ls $(psp-config --psp-prefix)/lib/libz.a $(psp-config --psp-prefix)/include/zziplib.h
+


### PR DESCRIPTION
This makes sure the libraries.sh script does not try to rebuild the zziplib library if it is already installed. Without this it is build and fails to install, because the files already exist.