### PR TITLE
Check in correct place for cmake toolchain script

### DIFF
--- a/depends/check-cmake-toolchain-script.sh
+++ b/depends/check-cmake-toolchain-script.sh
@@ -4,4 +4,4 @@
  ## Check for cmake toolchain script.
  ls \
      $(psp-config --pspdev-path)/bin/psp-cmake \
-     $(psp-config --psp-prefix)/share/cmake-2.8/Modules/Platform/PSP.cmake
+     $(psp-config --psp-prefix)/share/cmake/PSP.cmake


### PR DESCRIPTION
The cmake toolchain script is installed in a different place than where
the check-cmake-toolchain-script script is looking by scripts in this
repo.