### PR TITLE
Fix SDL_gfx not installing

### DIFF
--- a/scripts/SDL_gfx.sh
+++ b/scripts/SDL_gfx.sh
@@ -1,7 +1,7 @@
 test_deps_install SDL
 download_and_extract http://sourceforge.net/projects/sdlgfx/files/SDL_gfx-2.0.25.tar.gz SDL_gfx-2.0.25
 apply_patch SDL_gfx-2.0.25-PSP
-autoreconf --force --install
+autoreconf --force --install -I $(psp-config --psp-prefix)/share/aclocal
 cp ../../patches/config.sub ./config.sub
 run_configure --prefix=$(psp-config --psp-prefix) --host=psp --disable-mmx --disable-shared
 run_make


### PR DESCRIPTION
It probably still needs SDL to be installed before it, but adding this made me able to build SDL_gfx.

On my system I see SDL_gfx, SDL_image, SDL_ttf and squirrel failing to build. I'll see if I can find a fix for all of them in the coming days.