### PR TITLE
Use psp-g++ as compiler for squirrel

### DIFF
--- a/scripts/squirrel.sh
+++ b/scripts/squirrel.sh
@@ -1,6 +1,6 @@
 download_and_extract http://sourceforge.net/projects/squirrel/files/squirrel_3_0_7_stable.tar.gz SQUIRREL3
 apply_patch squirrel-3.0.7
-AR="psp-ar" CC="psp-gcc" CXX="psp-g++" LIBS="-lc -lpspuser" make -j `num_cpus` -C squirrel sq32
-AR="psp-ar" CC="psp-gcc" CXX="psp-g++" LIBS="-lc -lpspuser" make -j `num_cpus` -C sqstdlib sq32
+AR="psp-ar" CC="psp-g++" CXX="psp-g++" LIBS="-lc -lpspuser" make -j `num_cpus` -C squirrel sq32
+AR="psp-ar" CC="psp-g++" CXX="psp-g++" LIBS="-lc -lpspuser" make -j `num_cpus` -C sqstdlib sq32
 cp -v lib/*.a $(psp-config --psp-prefix)/lib
 cp -v include/*.h $(psp-config --psp-prefix)/include


### PR DESCRIPTION
It was failing to build in my docker environment with an error saying I didn't have c++ compiler. Using psp-g++ fixes this.