### PR TITLE
Fix for multiple libraries not installing correctly in Ubuntu and Debian

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -31,7 +31,7 @@ function test_deps_install {
         test_dep $dep || {
             script2="$basepath/scripts/$dep.sh"
             if [ -x $script2 ]; then
-                sh -c "source $basepath/common.sh; set -e; basepath=$basepath; source $script2" || { echo "Couldn't install dependency $dep, aborting."; return 1; }
+                bash -c "source $basepath/common.sh; set -e; basepath=$basepath; source $script2" || { echo "Couldn't install dependency $dep, aborting."; return 1; }
             else
                 echo "Dependency $dep required but not found. Please install it."
                 return 1

--- a/scripts/pixman.sh
+++ b/scripts/pixman.sh
@@ -1,3 +1,4 @@
+test_deps_install libpng
 PIXMAN_VERSION=0.24.4
 
 download_and_extract http://cairographics.org/releases/pixman-$PIXMAN_VERSION.tar.gz pixman-$PIXMAN_VERSION


### PR DESCRIPTION
Ubuntu and Debian do not have /bin/sh linked to bash, so the installation script was not being run. This cause multiple dependency issues. I've also found that pixman didn't include a dependency check of libpng, which it does need.

This resolves https://github.com/pspdev/psptoolchain/issues/112