### PR TITLE
Added useful utility libraries for the PSP development scene.

### DIFF
--- a/depends/check-libme.sh
+++ b/depends/check-libme.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+PREFIX=$(psp-config --psp-prefix)
+
+ls $PREFIX/lib/libME.a $PREFIX/include/MElib

--- a/depends/check-libperf.sh
+++ b/depends/check-libperf.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+PREFIX=$(psp-config --psp-prefix)
+
+ls $PREFIX/lib/libPerf.a

--- a/depends/check-libperf.sh
+++ b/depends/check-libperf.sh
@@ -2,4 +2,4 @@
 
 PREFIX=$(psp-config --psp-prefix)
 
-ls $PREFIX/lib/libPerf.a
+ls $PREFIX/lib/libPerf.a $PREFIX/include/perflib.h

--- a/scripts/libme.sh
+++ b/scripts/libme.sh
@@ -1,5 +1,7 @@
 download_and_extract https://github.com/NT-Bourgeois-Iridescence-Technologies/MElib/archive/master.zip MElib
 make
+mkdir -p $(psp-config --psp-prefix)/bin/MElib
 mkdir -p $(psp-config --psp-prefix)/include/MElib
 cp -v include/*.h $(psp-config --psp-prefix)/include/MElib
+cp -v bin/*.prx $(psp-config --psp-prefix)/bin/MElib
 cp -v libME.a $(psp-config --psp-prefix)/lib

--- a/scripts/libme.sh
+++ b/scripts/libme.sh
@@ -1,5 +1,5 @@
 download_and_extract https://github.com/NT-Bourgeois-Iridescence-Technologies/MElib/archive/v1.1.tar.gz MElib
-make
+make -f MakefileLib
 mkdir -p $(psp-config --psp-prefix)/bin/MElib
 mkdir -p $(psp-config --psp-prefix)/include/MElib
 cp -v include/*.h $(psp-config --psp-prefix)/include/MElib

--- a/scripts/libme.sh
+++ b/scripts/libme.sh
@@ -1,4 +1,4 @@
-download_and_extract https://github.com/NT-Bourgeois-Iridescence-Technologies/MElib/archive/master.zip MElib
+download_and_extract https://github.com/NT-Bourgeois-Iridescence-Technologies/MElib/archive/v1.1.tar.gz MElib
 make
 mkdir -p $(psp-config --psp-prefix)/bin/MElib
 mkdir -p $(psp-config --psp-prefix)/include/MElib

--- a/scripts/libme.sh
+++ b/scripts/libme.sh
@@ -1,0 +1,5 @@
+download_and_extract https://github.com/NT-Bourgeois-Iridescence-Technologies/MElib/archive/master.zip MElib
+make
+mkdir -p $(psp-config --psp-prefix)/include/MElib
+cp -v include/*.h $(psp-config --psp-prefix)/include/MElib
+cp -v libME.a $(psp-config --psp-prefix)/lib

--- a/scripts/libme.sh
+++ b/scripts/libme.sh
@@ -1,7 +1,7 @@
-download_and_extract https://github.com/NT-Bourgeois-Iridescence-Technologies/MElib/archive/v1.1.tar.gz MElib
+download_and_extract https://github.com/NT-Bourgeois-Iridescence-Technologies/MElib/archive/v1.1.tar.gz MElib-1.1
 make -f MakefileLib
 mkdir -p $(psp-config --psp-prefix)/bin/MElib
 mkdir -p $(psp-config --psp-prefix)/include/MElib
 cp -v include/*.h $(psp-config --psp-prefix)/include/MElib
 cp -v bin/*.prx $(psp-config --psp-prefix)/bin/MElib
-cp -v libME.a $(psp-config --psp-prefix)/lib
+cp -v lib/libME.a $(psp-config --psp-prefix)/lib

--- a/scripts/libperf.sh
+++ b/scripts/libperf.sh
@@ -1,5 +1,5 @@
 download_and_extract https://github.com/NT-Bourgeois-Iridescence-Technologies/PerfLib/archive/master.zip PerfLib
 make
 mkdir -p $(psp-config --psp-prefix)/include/
-cp -v include/*.h $(psp-config --psp-prefix)/include/
+cp -v include/perflib.h $(psp-config --psp-prefix)/include/
 cp -v libPerf.a $(psp-config --psp-prefix)/lib

--- a/scripts/libperf.sh
+++ b/scripts/libperf.sh
@@ -1,0 +1,5 @@
+download_and_extract https://github.com/NT-Bourgeois-Iridescence-Technologies/PerfLib/archive/master.zip PerfLib
+make
+mkdir -p $(psp-config --psp-prefix)/include/
+cp -v include/*.h $(psp-config --psp-prefix)/include/
+cp -v libPerf.a $(psp-config --psp-prefix)/lib

--- a/scripts/libperf.sh
+++ b/scripts/libperf.sh
@@ -1,5 +1,5 @@
-download_and_extract https://github.com/NT-Bourgeois-Iridescence-Technologies/PerfLib/archive/master.zip PerfLib
-make
+download_and_extract https://github.com/NT-Bourgeois-Iridescence-Technologies/PerfLib/archive/master.zip PerfLib-master
+make -f MakefileLib
 mkdir -p $(psp-config --psp-prefix)/include/
 cp -v include/perflib.h $(psp-config --psp-prefix)/include/
-cp -v libPerf.a $(psp-config --psp-prefix)/lib
+cp -v lib/libPerf.a $(psp-config --psp-prefix)/lib


### PR DESCRIPTION
Hello! I'm not necessarily sure of the formal process for adding libraries, but I have both MElib and PerfLib to add to the standard library collection. These two libraries are useful for PSP optimization. MElib allows PSP developers to use the Media Engine in order to fully optimize and harness the power of the second CPU. The other library, PerfLib creates simple methods for PSP developers to track the overall performance of their application in terms of CPU, GPU, and VBlank times, and CPU and GPU percentages. It also allows for "frame-relative" CPU and GPU percentages which allows developers to spot bottlenecks in their applications. Both are written in plain C.