### PR TITLE
-lGL needs -lm

### DIFF
--- a/patches/SDL-1.2.15-PSP.patch
+++ b/patches/SDL-1.2.15-PSP.patch
@@ -34,7 +34,7 @@ diff -burN SDL-1.2.15/configure.in SDL-1.2.15-PSP/configure.in
 +        AC_MSG_RESULT($video_opengl)
 +        if test x$video_opengl = xyes; then
 +            EXTRA_CFLAGS="$EXTRA_CFLAGS -DHAVE_OPENGL"
-+            EXTRA_LDFLAGS="$EXTRA_LDFLAGS -lGL -lpspvfpu"
++            EXTRA_LDFLAGS="$EXTRA_LDFLAGS -lGL -lm -lpspvfpu"
 +        fi
 +    fi
 +}


### PR DESCRIPTION
This PR fixes linker errors when building SDL_Image and SDL_ttf :

```
/usr/local/pspdev/psp/lib/libGL.a(glLight.o): In function `glLightfv':
(.text+0xdf8): undefined reference to `cosf'
collect2: error: ld returned 1 exit status
/usr/local/pspdev/psp/lib/libGL.a(glLight.o): In function `glLightfv':
(.text+0xdf8): undefined reference to `cosf'
collect2: error: ld returned 1 exit status
```

```
/usr/local/pspdev/psp/lib/libGL.a(glLight.o): In function `glLightfv':
(.text+0xdf8): undefined reference to `cosf'
collect2: error: ld returned 1 exit status
```