### PR TITLE
Fix check for libzzip library file

### DIFF
--- a/depends/check-zziplib.sh
+++ b/depends/check-zziplib.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
- ls $(psp-config --psp-prefix)/lib/libz.a $(psp-config --psp-prefix)/include/zziplib.h
+ ls $(psp-config --psp-prefix)/lib/libzzip.a $(psp-config --psp-prefix)/include/zziplib.h
 


### PR DESCRIPTION
I was checking for libz instead, which is a different library. I've tested it in my pspdev docker container like so:
```
root@56e91ea4b39d:/build/psplibraries#  ls $(psp-config --psp-prefix)/lib/libzzip.a $(psp-config --psp-prefix)/include/zziplib.h
/usr/local/pspdev/psp/include/zziplib.h  /usr/local/pspdev/psp/lib/libzzip.a
root@56e91ea4b39d:/build/psplibraries# echo $?
0
```