### PR TITLE
Updated cmake toolchain file.

### DIFF
--- a/depends/check-cmake-toolchain-script.sh
+++ b/depends/check-cmake-toolchain-script.sh
@@ -4,4 +4,5 @@
  ## Check for cmake toolchain script.
  ls \
      $(psp-config --pspdev-path)/bin/psp-cmake \
-     $(psp-config --psp-prefix)/share/cmake/PSP.cmake
+     $(psp-config --psp-prefix)/share/cmake/PSP.cmake \
+     $(psp-config --psp-prefix)/share/cmake/CreatePBP.cmake

--- a/patches/CreatePBP.cmake
+++ b/patches/CreatePBP.cmake
@@ -1,0 +1,66 @@
+# File defining macro outputting PSP-specific EBOOT.PBP out of passed executable target.
+# Copyright 2020 - Daniel 'dbeef' Zalega
+#
+# Args:
+# TARGET - defined by an add_executable call before calling create_pbp_file
+# ICON_PATH - optional, absolute path to .png file, 144x82
+# BACKGROUND_PATH - optional, absolute path to .png file, 480x272
+# PREVIEW_PATH - optional, absolute path to .png file, 480x272
+#
+cmake_minimum_required(VERSION 3.10)
+
+macro(create_pbp_file)
+
+    set(oneValueArgs TARGET ICON_PATH BACKGROUND_PATH PREVIEW_PATH)
+    cmake_parse_arguments("ARG" "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    # As pack-pbp takes undefined arguments in form of "NULL" string,
+    # set each undefined macro variable to such value:
+    foreach(arg ${oneValueArgs})
+        if (NOT DEFINED ARG_${arg})
+            set(ARG_${arg} "NULL")
+        endif()
+    endforeach()
+
+    add_custom_command(TARGET ${ARG_TARGET} POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E make_directory
+            $<TARGET_FILE_DIR:${ARG_TARGET}>/psp_artifact
+            COMMENT "Creating psp_artifact directory."
+    )
+
+    add_custom_command(TARGET ${ARG_TARGET} POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            $<TARGET_FILE:${ARG_TARGET}>
+            $<TARGET_FILE_DIR:${ARG_TARGET}>/psp_artifact
+            COMMENT "Copying ELF to psp_arfitact directory."
+    )
+
+    add_custom_command(
+            TARGET ${ARG_TARGET}
+            POST_BUILD COMMAND
+            "${FIXUP}" "$<TARGET_FILE_DIR:${ARG_TARGET}>/psp_artifact/${ARG_TARGET}"
+            COMMENT "Calling psp-fixup-imports"
+    )
+
+    add_custom_command(
+            TARGET ${ARG_TARGET}
+            POST_BUILD COMMAND
+            "${MKSFOEX}" "-d" "MEMSIZE=1" "$<TARGET_FILE_DIR:${ARG_TARGET}>/psp_artifact/${ARG_TARGET}" "PARAM.SFO"
+            COMMENT "Calling mksfoex"
+    )
+
+    add_custom_command(
+            TARGET ${ARG_TARGET}
+            POST_BUILD COMMAND
+            "${PACK_PBP}" "EBOOT.PBP" "PARAM.SFO" "${ARG_ICON_PATH}" "NULL" "${ARG_PREVIEW_PATH}"
+            "${ARG_BACKGROUND_PATH}" "NULL" "$<TARGET_FILE_DIR:${ARG_TARGET}>/psp_artifact/${ARG_TARGET}" "NULL"
+            COMMENT "Calling pack-pbp"
+    )
+
+    add_custom_command(
+            TARGET ${ARG_TARGET}
+            POST_BUILD COMMAND
+            ${CMAKE_COMMAND} -E cmake_echo_color --cyan "EBOOT.PBP file created."
+    )
+
+endmacro()

--- a/patches/PSP.cmake
+++ b/patches/PSP.cmake
@@ -1,34 +1,67 @@
-SET(CMAKE_SYSTEM_NAME Generic)
-SET(CMAKE_SYSTEM_VERSION 1)
-SET(CMAKE_CROSSCOMPILING TRUE)
+#
+# CMake toolchain file for PSP.
+#
+# Copyright 2019 - Wally
+# Copyright 2020 - Daniel 'dbeef' Zalega
 
-# set compiler
-set(CMAKE_C_COMPILER psp-gcc)
-set(CMAKE_CXX_COMPILER psp-g++)
+if (DEFINED PSPDEV)
+    # Custom PSPDEV passed as cmake call argument.
+else()
+    # Determine PSP toolchain installation directory;
+    # psp-config binary is guaranteed to be in path after successful installation:
+    execute_process(COMMAND bash -c "psp-config --pspdev-path" OUTPUT_VARIABLE PSPDEV OUTPUT_STRIP_TRAILING_WHITESPACE)
+endif()
 
-SET(BUILD_SHARED_LIBS FALSE)
-SET(CMAKE_EXECUTABLE_SUFFIX ".elf")
+# Assert that PSP SDK path is now defined:
+if (NOT DEFINED PSPDEV)
+    message(FATAL_ERROR "PSPDEV not defined. Make sure psp-config in your path or pass custom \
+                        toolchain location via PSPDEV variable in cmake call.")
+endif ()
 
-# set find root path
-execute_process(COMMAND psp-config --pspsdk-path
-  OUTPUT_VARIABLE PSPSDK_PATH
-  OUTPUT_STRIP_TRAILING_WHITESPACE)
+# Set helper variables:
+set(PSPSDK ${PSPDEV}/psp/sdk)
+set(PSPBIN ${PSPDEV}/bin)
+set(PSPCMAKE ${PSPDEV}/psp/share/cmake)
 
-execute_process(COMMAND psp-config --psp-prefix
-  OUTPUT_VARIABLE PSP_PREFIX
-  OUTPUT_STRIP_TRAILING_WHITESPACE)
+# Basic CMake Declarations
+set(CMAKE_SYSTEM_NAME Generic)
+set(CMAKE_C_COMPILER ${PSPBIN}/psp-gcc)
+set(CMAKE_CXX_COMPILER ${PSPBIN}/psp-g++)
+set(CMAKE_FIND_ROOT_PATH "${PSPSDK};${PSPDEV}")
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 
-set(CMAKE_FIND_ROOT_PATH "${PSPSDK_PATH};${PSP_PREFIX}")
-include_directories(SYSTEM "${PSPSDK_PATH}/include;${PSP_PREFIX}/include")
+# Set paths to PSP-specific utilities:
+set(MKSFO ${PSPBIN}/mksfo)
+set(MKSFOEX ${PSPBIN}/mksfoex)
+set(PACK_PBP ${PSPBIN}/pack-pbp)
+set(FIXUP ${PSPBIN}/psp-fixup-imports)
+set(ENC ${PSPBIN}/PrxEncrypter)
 
-SET(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
-SET(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
-SET(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+# Include directories:
+include_directories(${include_directories} ${PSPDEV}/include ${PSPSDK}/include)
 
-# reduce link error
-ADD_DEFINITIONS("-G0")
+# Discard debug information:
+add_definitions("-G0")
 
-# linker flags
-set(PSP_LIBRARIES "-lpspdebug -lpspdisplay -lpspge -lpspctrl -lc -lpspsdk -lc -lpspnet -lpspnet_inet -lpspnet_apctl -lpspnet_resolver -lpspaudiolib -lpsputility -lpspuser -lpspkernel -L${PSPSDK_PATH}/lib -L${PSP_PREFIX}/lib")
+# Definitions that may be needed to use some libraries:
+add_definitions("-D__PSP__")
+add_definitions("-DHAVE_OPENGL")
+
+# Pass these libraries to linker calls by default:
+set(PSP_LIBRARIES
+        "-lc -lpspdebug -lpspdisplay -lpspge -lpspctrl -lpspsdk \
+        -lpspnet -lpspnet_inet -lpspnet_apctl -lpspnet_resolver -lpspaudiolib \
+        -lpsputility -lpspuser -lpspkernel -L${PSPSDK}/lib -L${PSPDEV}/lib"
+)
+
 set(CMAKE_C_STANDARD_LIBRARIES "${PSP_LIBRARIES}")
 set(CMAKE_CXX_STANDARD_LIBRARIES "-lstdc++ ${PSP_LIBRARIES}")
+
+# File defining macro outputting PSP-specific EBOOT.PBP out of passed executable target:
+include("${PSPCMAKE}/CreatePBP.cmake")
+
+# Helper variable for multi-platform projects to identify current platform:
+set(PLATFORM_PSP TRUE BOOL)

--- a/scripts/cmake-toolchain-script.sh
+++ b/scripts/cmake-toolchain-script.sh
@@ -4,8 +4,11 @@ DESTDIR=$1
 PSP_CMAKE_PATH=${DESTDIR}$(psp-config --pspdev-path)/bin
 TOOLCHAIN_SCRIPT_PATH=${DESTDIR}$(psp-config --psp-prefix)/share/cmake
 
-## copy toolchain script and psp-cmake
+## copy toolchain script
 install -d $TOOLCHAIN_SCRIPT_PATH
 install -m644 ../patches/PSP.cmake $TOOLCHAIN_SCRIPT_PATH || { exit 1; }
+## copy CreatePBP.cmake
+install -m644 ../patches/CreatePBP.cmake $TOOLCHAIN_SCRIPT_PATH || { exit 1; }
+## copy psp-cmake
 install -d $PSP_CMAKE_PATH
 install -m755 ../patches/psp-cmake $PSP_CMAKE_PATH || { exit 1; }


### PR DESCRIPTION
I wanted to share `CreatePBP.cmake`, which I previously wrote for my Spelunky-PSP project.
It defines a cmake macro for creating PSP executables.

Now, the shortest working example that you can write and run on PSP would be:

`CMakeLists.txt`
```cmake
cmake_minimum_required(VERSION 3.10)
add_executable(test-cmake main.cpp)
target_link_libraries(test-cmake PRIVATE SDL SDLmain)
create_pbp_file(
    TARGET test-cmake 
    ICON_PATH NULL 
    BACKGROUND_PATH NULL
    PREVIEW_PATH NULL
)
```
`main.cpp`
```cpp
#include <SDL/SDL.h>
extern "C"
{
	int SDL_main(int argc, char *argv[])
	{
		while(true){}
	}
}
```

built with:

```
mkdir build
cd build
psp-cmake ..
cmake --build . 
```

CreatePBP macro arguments are optional, so the sample call can be boiled down to:
```cmake
create_pbp_file(TARGET test-cmake)
```
But I wanted to show all possible arguments.

Besides the macro, I updated the cmake toolchain file `PSP.cmake` with a mix of the one from Daedalus project by [Wally4000](https://github.com/wally4000) and my changes made in Spelunky-PSP toolchain.

Squash before merging!