### PR TITLE
Modified list of implicitly linked libraries in PSP.cmake

### DIFF
--- a/patches/PSP.cmake
+++ b/patches/PSP.cmake
@@ -50,18 +50,15 @@ add_definitions("-G0")
 add_definitions("-D__PSP__")
 add_definitions("-DHAVE_OPENGL")
 
-# Pass these libraries to linker calls by default:
+# Aggregated list of all PSP-specific libraries for convenience.
 set(PSP_LIBRARIES
         "-lg -lc -lpspdebug -lpspctrl -lpspsdk \
         -lpspnet -lpspnet_inet -lpspnet_apctl -lpspnet_resolver -lpspaudiolib \
         -lpsputility -lGL \
-        -lpspvfpu -lpspdisplay -lpsphprm \
+        -lpspvfpu -lpspdisplay -lpsphprm -lpspirkeyb \
         -lpsprtc -lpspaudio -lpspvram  -lpspgu -lpspge -lpspuser \
         -L${PSPSDK}/lib -L${PSPDEV}/lib"
 )
-
-set(CMAKE_C_STANDARD_LIBRARIES "${PSP_LIBRARIES}")
-set(CMAKE_CXX_STANDARD_LIBRARIES "-lstdc++ ${PSP_LIBRARIES}")
 
 # File defining macro outputting PSP-specific EBOOT.PBP out of passed executable target:
 include("${PSPCMAKE}/CreatePBP.cmake")

--- a/patches/PSP.cmake
+++ b/patches/PSP.cmake
@@ -52,9 +52,12 @@ add_definitions("-DHAVE_OPENGL")
 
 # Pass these libraries to linker calls by default:
 set(PSP_LIBRARIES
-        "-lg -lc -lpspdebug -lpspdisplay -lpspge -lpspctrl -lpspsdk \
+        "-lg -lc -lpspdebug -lpspctrl -lpspsdk \
         -lpspnet -lpspnet_inet -lpspnet_apctl -lpspnet_resolver -lpspaudiolib \
-        -lpsputility -lpspuser -lpspkernel -L${PSPSDK}/lib -L${PSPDEV}/lib"
+        -lpsputility -lGL \
+        -lpspvfpu -lpspdisplay -lpsphprm \
+        -lpsprtc -lpspaudio -lpspvram  -lpspgu -lpspge -lpspuser \
+        -L${PSPSDK}/lib -L${PSPDEV}/lib"
 )
 
 set(CMAKE_C_STANDARD_LIBRARIES "${PSP_LIBRARIES}")


### PR DESCRIPTION
This is to use Joel16's SDL2 port from https://github.com/pspdev/psplibraries/pull/45 without explicitly linking to PSP-SDK libraries.

Test snippet:

`CMakeLists.txt`
```cmake
cmake_minimum_required(VERSION 3.10)
add_executable(test-cmake main.cpp)

target_link_libraries(test-cmake PRIVATE /home/dbeef/joel16-SDL2/libSDL2main.a SDL2)

create_pbp_file(
    TARGET test-cmake 
    ICON_PATH NULL 
    BACKGROUND_PATH NULL
    PREVIEW_PATH NULL
)
```
`main.cpp`
```cpp
#include <SDL2/SDL.h>

extern "C"
{
	int SDL_main(int argc, char *argv[])
	{
		while(true){}
	}
}

```

I passed absolute path to `libSDL2main.a` as it's not currently built and installed by default, there's an ongoing work on fixing this.