### PR TITLE
Optional stripping of binary passed to create_pbp_file

### DIFF
--- a/patches/CreatePBP.cmake
+++ b/patches/CreatePBP.cmake
@@ -23,6 +23,21 @@ macro(create_pbp_file)
         endif()
     endforeach()
 
+    if("${CMAKE_BUILD_TYPE}" STREQUAL "Release")
+        add_custom_command(
+            TARGET ${ARG_TARGET}
+            POST_BUILD COMMAND
+            "${STRIP}" "$<TARGET_FILE:${ARG_TARGET}>"
+            COMMENT "Stripping binary"
+        )
+    else()
+        add_custom_command(
+            TARGET ${ARG_TARGET}
+            POST_BUILD COMMAND
+            ${CMAKE_COMMAND} -E cmake_echo_color --cyan "Not stripping binary, build type is ${CMAKE_BUILD_TYPE}."
+        )
+    endif()
+
     add_custom_command(
             TARGET ${ARG_TARGET} POST_BUILD
             COMMAND ${CMAKE_COMMAND} -E make_directory

--- a/patches/PSP.cmake
+++ b/patches/PSP.cmake
@@ -39,6 +39,7 @@ set(MKSFOEX ${PSPBIN}/mksfoex)
 set(PACK_PBP ${PSPBIN}/pack-pbp)
 set(FIXUP ${PSPBIN}/psp-fixup-imports)
 set(ENC ${PSPBIN}/PrxEncrypter)
+set(STRIP ${PSPBIN}/psp-strip)
 
 # Include directories:
 include_directories(${include_directories} ${PSPDEV}/include ${PSPSDK}/include)


### PR DESCRIPTION
As I am aware not everyone uses CMake in their everyday projects, I want to reach out and propose this optional `STRIP` argument to the `create_pbp_file` macro for more novice users.