### PR TITLE
SDL auxiliary library fixes

### DIFF
--- a/scripts/SDL2.sh
+++ b/scripts/SDL2.sh
@@ -1,3 +1,4 @@
+test_deps_install libpspvram pspgl
 download_and_extract https://github.com/joel16/SDL2/archive/2.0.9.tar.gz SDL2-2.0.9
 make -f Makefile.psp
 make -f Makefile.main.psp

--- a/scripts/SDL2_gfx.sh
+++ b/scripts/SDL2_gfx.sh
@@ -1,4 +1,8 @@
 test_deps_install SDL2
 get_pspport SDL_gfx SDL2_gfx-psp
+
+# This is used when there is no pkg-config, but needs sdl2-config
+#EXTRA_FLAGS="--with-sdl-prefix=$(psp-config --psp-prefix)"
+# Force pkg-config flags, until our SDL2 ships it
 SDL_CFLAGS="-I$(psp-config --psp-prefix)/include/SDL2" SDL_LIBS="-lSDL2" \
-  run_autogen_build --disable-mmx
+  run_autogen_build $EXTRA_FLAGS --disable-mmx

--- a/scripts/SDL2_image.sh
+++ b/scripts/SDL2_image.sh
@@ -1,5 +1,9 @@
 test_deps_install SDL2 libpng jpeg
 get_pspport SDL_image SDL2_image-psp
+
+# This is used when there is no pkg-config, but needs sdl2-config
+#EXTRA_FLAGS="--with-sdl-prefix=$(psp-config --psp-prefix)"
+# Force pkg-config flags, until our SDL2 ships it
 PKG_CONFIG_LIBDIR="$(psp-config --psp-prefix)/lib/pkgconfig" \
   SDL_CFLAGS="-I$(psp-config --psp-prefix)/include/SDL2" SDL_LIBS="-lSDL2" \
-  run_autogen_build
+  run_autogen_build $EXTRA_FLAGS

--- a/scripts/SDL2_mixer.sh
+++ b/scripts/SDL2_mixer.sh
@@ -1,5 +1,9 @@
 test_deps_install SDL2 libmikmod
 get_pspport SDL_mixer SDL2_mixer-psp
+
+# This is used when there is no pkg-config, but needs sdl2-config
+#EXTRA_FLAGS="--with-sdl-prefix=$(psp-config --psp-prefix)"
+# Force pkg-config flags, until our SDL2 ships it
 PKG_CONFIG_LIBDIR="$(psp-config --psp-prefix)/lib/pkgconfig" \
   SDL_CFLAGS="-I$(psp-config --psp-prefix)/include/SDL2" SDL_LIBS="-lSDL2" \
-  run_autogen_build --disable-music-cmd
+  run_autogen_build $EXTRA_FLAGS --disable-music-cmd

--- a/scripts/SDL2_ttf.sh
+++ b/scripts/SDL2_ttf.sh
@@ -2,4 +2,5 @@ test_deps_install SDL2 freetype
 get_pspport SDL_ttf SDL2_ttf-psp
 PKG_CONFIG_LIBDIR="$(psp-config --psp-prefix)/lib/pkgconfig" \
   SDL_CFLAGS="-I$(psp-config --psp-prefix)/include/SDL2" SDL_LIBS="-lSDL2" \
-  run_autogen_build --without-x
+  run_autogen_build --with-freetype-prefix=$(psp-config --psp-prefix) \
+  --without-x

--- a/scripts/SDL2_ttf.sh
+++ b/scripts/SDL2_ttf.sh
@@ -1,6 +1,11 @@
 test_deps_install SDL2 freetype
 get_pspport SDL_ttf SDL2_ttf-psp
+
+# This is used when there is no pkg-config, but needs sdl2-config
+#EXTRA_FLAGS="--with-sdl-prefix=$(psp-config --psp-prefix)"
+# This is used when there is no pkg-config, but needs freetype-config
+EXTRA_FLAGS="$EXTRA_FLAGS --with-freetype-prefix=$(psp-config --psp-prefix)"
+# Force pkg-config flags, until our SDL2 ships it
 PKG_CONFIG_LIBDIR="$(psp-config --psp-prefix)/lib/pkgconfig" \
   SDL_CFLAGS="-I$(psp-config --psp-prefix)/include/SDL2" SDL_LIBS="-lSDL2" \
-  run_autogen_build --with-freetype-prefix=$(psp-config --psp-prefix) \
-  --without-x
+  run_autogen_build $EXTRA_FLAGS --without-x

--- a/scripts/SDL_gfx.sh
+++ b/scripts/SDL_gfx.sh
@@ -1,6 +1,4 @@
 test_deps_install SDL
 get_pspport SDL_gfx SDL_gfx-psp
-autoreconf --force --install -I $(psp-config --psp-prefix)/share/aclocal
-cp ../../patches/config.sub ./config.sub
 run_autogen_build --with-sdl-prefix=$(psp-config --psp-prefix) \
   --disable-mmx

--- a/scripts/SDL_ttf.sh
+++ b/scripts/SDL_ttf.sh
@@ -1,4 +1,5 @@
 test_deps_install SDL freetype
 get_pspport SDL_ttf SDL_ttf-psp
-run_autogen_build --with-sdl-prefix=$(psp-config --psp-prefix) \
+PKG_CONFIG_LIBDIR="$(psp-config --psp-prefix)/lib/pkgconfig" \
+  run_autogen_build --with-sdl-prefix=$(psp-config --psp-prefix) \
   --with-freetype-prefix=$(psp-config --psp-prefix) --without-x

--- a/scripts/freetype.sh
+++ b/scripts/freetype.sh
@@ -1,4 +1,5 @@
 test_deps_install zlib
 get_pspport freetype2 freetype2-psp
 PKG_CONFIG_LIBDIR="$(psp-config --psp-prefix)/lib/pkgconfig" \
-  run_autogen_build --without-bzip2 --without-png
+  run_autogen_build --enable-freetype-config \
+  --without-bzip2 --without-png


### PR DESCRIPTION
- This fixes freetype2 config file generation and use
- Installs needed SDL2 dependencies

With this and installed pkg-config all libraries build again on docker and macOS.