### PR TITLE
Do not use sdl-config to check if SDL is installed

### DIFF
--- a/depends/check-SDL.sh
+++ b/depends/check-SDL.sh
@@ -1,3 +1,5 @@
 #!/bin/sh
- $(psp-config --psp-prefix)/bin/sdl-config --version
 
+ PREFIX=$(psp-config --psp-prefix)
+
+ ls $PREFIX/lib/libSDL.a $PREFIX/lib/libSDLmain.a $PREFIX/include/SDL

--- a/depends/check-SDL2.sh
+++ b/depends/check-SDL2.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+ PREFIX=$(psp-config --psp-prefix)
+
+ ls $PREFIX/lib/libSDL2.a $PREFIX/lib/libSDL2main.a $PREFIX/include/SDL2

--- a/depends/check-SDL2.sh
+++ b/depends/check-SDL2.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-
- PREFIX=$(psp-config --psp-prefix)
-
- ls $PREFIX/lib/libSDL2.a $PREFIX/lib/libSDL2main.a $PREFIX/include/SDL2


### PR DESCRIPTION
It seems sdl-config was used to check if SDL was installed correctly.