### PR TITLE
Initial support for building prx files with CMAKE

### DIFF
--- a/depends/check-cmake-toolchain-script.sh
+++ b/depends/check-cmake-toolchain-script.sh
@@ -5,4 +5,5 @@
  ls \
      $(psp-config --pspdev-path)/bin/psp-cmake \
      $(psp-config --psp-prefix)/share/cmake/PSP.cmake \
+     $(psp-config --psp-prefix)/share/cmake/BuildPRX.cmake \
      $(psp-config --psp-prefix)/share/cmake/CreatePBP.cmake

--- a/patches/BuildPRX.cmake
+++ b/patches/BuildPRX.cmake
@@ -1,0 +1,12 @@
+function(build_prx elf)
+	set(BUILD_PRX TRUE)
+	set(_PRX_FLAGS "-g3 -specs=${PSPSDK}/lib/prxspecs -Wl,-q,-T${PSPSDK}/lib/linkfile.prx")
+	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS_DEBUG} ${PRX_FLAGS}")
+	set(CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS_DEBUG} ${PRX_FLAGS}")
+
+	add_custom_command(
+		TARGET ${elf}
+		POST_BUILD COMMAND
+		${PRXGEN} ${elf} ${elf}.prx
+	)
+endfunction()

--- a/patches/BuildPRX.cmake
+++ b/patches/BuildPRX.cmake
@@ -1,12 +1,7 @@
-function(build_prx elf)
-	set(BUILD_PRX TRUE)
-	set(_PRX_FLAGS "-g3 -specs=${PSPSDK}/lib/prxspecs -Wl,-q,-T${PSPSDK}/lib/linkfile.prx")
-	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS_DEBUG} ${PRX_FLAGS}")
-	set(CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS_DEBUG} ${PRX_FLAGS}")
-
+macro(build_prx elf)
 	add_custom_command(
 		TARGET ${elf}
 		POST_BUILD COMMAND
 		${PRXGEN} ${elf} ${elf}.prx
 	)
-endfunction()
+endmacro()

--- a/patches/PSP.cmake
+++ b/patches/PSP.cmake
@@ -40,12 +40,17 @@ set(PACK_PBP ${PSPBIN}/pack-pbp)
 set(FIXUP ${PSPBIN}/psp-fixup-imports)
 set(ENC ${PSPBIN}/PrxEncrypter)
 set(STRIP ${PSPBIN}/psp-strip)
+set(PRXGEN ${PSPBIN}/psp-prxgen)
 
 # Include directories:
 include_directories(${include_directories} ${PSPDEV}/include ${PSPSDK}/include)
 
-# Discard debug information:
-add_definitions("-G0")
+# Set flags for building prx files for non-release builds
+if(NOT "${CMAKE_BUILD_TYPE}" STREQUAL "Release")
+	set(_DEBUG_FLAGS "-ggdb -specs=${PSPSDK}/lib/prxspecs -Wl,-q,-T${PSPSDK}/lib/linkfile.prx")
+	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS_DEBUG} ${_DEBUG_FLAGS}")
+	set(CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS_DEBUG} ${_DEBUG_FLAGS}")
+endif()
 
 # Definitions that may be needed to use some libraries:
 add_definitions("-D__PSP__")
@@ -62,6 +67,7 @@ set(PSP_LIBRARIES
 )
 
 # File defining macro outputting PSP-specific EBOOT.PBP out of passed executable target:
+include("${PSPCMAKE}/BuildPRX.cmake")
 include("${PSPCMAKE}/CreatePBP.cmake")
 
 # Helper variable for multi-platform projects to identify current platform:

--- a/scripts/cmake-toolchain-script.sh
+++ b/scripts/cmake-toolchain-script.sh
@@ -7,6 +7,8 @@ TOOLCHAIN_SCRIPT_PATH=${DESTDIR}$(psp-config --psp-prefix)/share/cmake
 ## copy toolchain script
 install -d $TOOLCHAIN_SCRIPT_PATH
 install -m644 ../patches/PSP.cmake $TOOLCHAIN_SCRIPT_PATH || { exit 1; }
+## copy BuildPRX.cmake
+install -m644 ../patches/BuildPRX.cmake $TOOLCHAIN_SCRIPT_PATH || { exit 1; }
 ## copy CreatePBP.cmake
 install -m644 ../patches/CreatePBP.cmake $TOOLCHAIN_SCRIPT_PATH || { exit 1; }
 ## copy psp-cmake


### PR DESCRIPTION
This is still WIP, because I'm still having some issues with it, but
a prx is being build. When launching the prx file it builds with psplink, my PSP crashes, though. I could use some help figuring this out.

I'm using pretty much the same cflags as build.mak when BUILD_PRX is set. 

Using this is quite simple, just use the ``build_prx(binary)`` in your
CMakeLists.txt. Do make sure to replace binary with your binary target.