### PR TITLE
Install SDL2 version 2.0.12

### DIFF
--- a/scripts/SDL2.sh
+++ b/scripts/SDL2.sh
@@ -1,5 +1,5 @@
 test_deps_install libpspvram pspgl
-download_and_extract https://github.com/joel16/SDL2/archive/2.0.9.tar.gz SDL2-2.0.9
+download_and_extract https://github.com/joel16/SDL2/archive/SDL-2.0.12.tar.gz SDL2-SDL-2.0.12
 make -f Makefile.psp
 make -f Makefile.main.psp
 mkdir -p $(psp-config --psp-prefix)/include/SDL2


### PR DESCRIPTION
In Joel's repository SDL2 was finally mostly fixed in version 2.0.12. Before there was some artifacting and the video memory would run out when loading more than one image or a bigger image. There is still an issue with SDL2_ttf, but it is a big upgrade either way.