### PR TITLE
Update to version 2.3.0 of expat

### DIFF
--- a/scripts/expat.sh
+++ b/scripts/expat.sh
@@ -1,4 +1,4 @@
-EXPAT_VERSION=2.1.0
+EXPAT_VERSION=2.3.0
 
 download_and_extract "http://sourceforge.net/projects/expat/files/expat/$EXPAT_VERSION/expat-$EXPAT_VERSION.tar.gz"  expat-$EXPAT_VERSION
 ## Patch


### PR DESCRIPTION
The source for version 2.1.0 is no longer offered because of a security issue. The documentation recommends using version 2.3.0, which does build with our patch. I haven't tested using the library, though, it might be broken in some way, but I don't know what project I can use to test it.