### PR TITLE
Added missing shebangs required for MinGW

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 # Returns the number of processor cores available
 # Usage: num_cpus
 function num_cpus

--- a/scripts/SDL.sh
+++ b/scripts/SDL.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 git clone https://github.com/pspdev/SDL SDL -b psp-v.1.2.15 
 cd SDL
 

--- a/scripts/SDL2.sh
+++ b/scripts/SDL2.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 test_deps_install libpspvram pspgl
 git clone https://github.com/pspdev/SDL SDL2 -b psp-v2.0.14 --depth=1 
 

--- a/scripts/SDL2_gfx.sh
+++ b/scripts/SDL2_gfx.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 test_deps_install SDL2
 get_pspport SDL_gfx SDL2_gfx-psp
 

--- a/scripts/SDL2_image.sh
+++ b/scripts/SDL2_image.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 test_deps_install SDL2 libpng jpeg
 get_pspport SDL_image SDL2_image-psp
 

--- a/scripts/SDL2_mixer.sh
+++ b/scripts/SDL2_mixer.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 test_deps_install SDL2 libmikmod
 get_pspport SDL_mixer SDL2_mixer-psp
 

--- a/scripts/SDL2_ttf.sh
+++ b/scripts/SDL2_ttf.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 test_deps_install SDL2 freetype
 get_pspport SDL_ttf SDL2_ttf-psp
 

--- a/scripts/SDL_gfx.sh
+++ b/scripts/SDL_gfx.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 test_deps_install SDL
 get_pspport SDL_gfx SDL_gfx-psp
 run_autogen_build --with-sdl-prefix=$(psp-config --psp-prefix) \

--- a/scripts/SDL_image.sh
+++ b/scripts/SDL_image.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 test_deps_install SDL libpng jpeg
 get_pspport SDL_image SDL_image-psp
 run_autogen_build --with-sdl-prefix=$(psp-config --psp-prefix)

--- a/scripts/SDL_mixer.sh
+++ b/scripts/SDL_mixer.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 test_deps_install SDL libmikmod
 get_pspport SDL_mixer SDL_mixer-psp
 run_autogen_build --with-sdl-prefix=$(psp-config --psp-prefix) \

--- a/scripts/SDL_ttf.sh
+++ b/scripts/SDL_ttf.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 test_deps_install SDL freetype
 get_pspport SDL_ttf SDL_ttf-psp
 run_autogen_build --with-sdl-prefix=$(psp-config --psp-prefix) \

--- a/scripts/angelscript.sh
+++ b/scripts/angelscript.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 ## test dependency
 test_deps_install cmake-toolchain-script
 

--- a/scripts/bzip2.sh
+++ b/scripts/bzip2.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 BZIP2_VERSION=1.0.6
 
 download_and_extract ftp://sourceware.org/pub/bzip2/bzip2-$BZIP2_VERSION.tar.gz bzip2-$BZIP2_VERSION

--- a/scripts/expat.sh
+++ b/scripts/expat.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 EXPAT_VERSION=2.4.1
 
 download_and_extract "http://sourceforge.net/projects/expat/files/expat/$EXPAT_VERSION/expat-$EXPAT_VERSION.tar.gz"  expat-$EXPAT_VERSION

--- a/scripts/freetype.sh
+++ b/scripts/freetype.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 test_deps_install zlib
 get_pspport freetype2 freetype2-psp
 run_autogen_build --enable-freetype-config \

--- a/scripts/jpeg.sh
+++ b/scripts/jpeg.sh
@@ -1,2 +1,3 @@
+#!/bin/sh
 get_pspports jpeg
 run_make -j `num_cpus`

--- a/scripts/kubridge.sh
+++ b/scripts/kubridge.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 git clone https://github.com/pspdev/kubridge
 cd kubridge; mkdir build; cd build
 psp-cmake ..; make; make install

--- a/scripts/libbulletml.sh
+++ b/scripts/libbulletml.sh
@@ -1,2 +1,3 @@
+#!/bin/sh
 get_pspports libbulletml/src
 run_make -j `num_cpus`

--- a/scripts/libmad.sh
+++ b/scripts/libmad.sh
@@ -1,2 +1,3 @@
+#!/bin/sh
 get_pspports libmad
 run_make -j `num_cpus`

--- a/scripts/libmikmod.sh
+++ b/scripts/libmikmod.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 download_and_extract https://downloads.sourceforge.net/mikmod/libmikmod-3.3.11.1.tar.gz libmikmod-3.3.11.1
 
 apply_patch libmikmod-3.3.11.1-PSP

--- a/scripts/libogg.sh
+++ b/scripts/libogg.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 get_pspports libogg
 LDFLAGS="-L$(psp-config --pspsdk-path)/lib" LIBS="-lc -lpspuser" ./autogen.sh --host psp --prefix=$(psp-config --psp-prefix)
 run_make -j `num_cpus`

--- a/scripts/libpng.sh
+++ b/scripts/libpng.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 test_deps_install zlib
 
 LIBPNG_VERSION=1.5.7

--- a/scripts/libpspvram.sh
+++ b/scripts/libpspvram.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 clone_git_repo github.com albe libpspvram main
 cd libpspvram
 run_make

--- a/scripts/libtremor.sh
+++ b/scripts/libtremor.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 get_pspports libTremor
 LDFLAGS="-L$(psp-config --pspsdk-path)/lib" LIBS="-lc -lpspuser" ./autogen.sh --host psp --prefix=$(psp-config --psp-prefix) || { exit 1; }
 run_make -j `num_cpus`

--- a/scripts/libvorbis.sh
+++ b/scripts/libvorbis.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 get_pspports libvorbis
 LDFLAGS="-L$(psp-config --pspsdk-path)/lib" LIBS="-lc -lpspuser" ./autogen.sh --host psp --prefix=$(psp-config --psp-prefix) || { exit 1; }
 run_make -j `num_cpus`

--- a/scripts/libyaml.sh
+++ b/scripts/libyaml.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 LIBYAML_VERSION=0.1.4
 
 download_and_extract http://pyyaml.org/download/libyaml/yaml-$LIBYAML_VERSION.tar.gz yaml-$LIBYAML_VERSION

--- a/scripts/lua.sh
+++ b/scripts/lua.sh
@@ -1,2 +1,3 @@
+#!/bin/sh
 get_pspports lua
 make -f Makefile.psp -j `num_cpus` && make -f Makefile.psp install

--- a/scripts/opentri.sh
+++ b/scripts/opentri.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 test_deps_install zlib freetype
 
 wget --continue --no-check-certificate https://github.com/SamRH/openTRI/tarball/master -O openTRI.tar.gz

--- a/scripts/pixman.sh
+++ b/scripts/pixman.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 test_deps_install libpng
 PIXMAN_VERSION=0.24.4
 

--- a/scripts/pspgl.sh
+++ b/scripts/pspgl.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 get_pspport pspgl
 
 run_make -j `num_cpus`

--- a/scripts/pspirkeyb.sh
+++ b/scripts/pspirkeyb.sh
@@ -1,2 +1,3 @@
+#!/bin/sh
 get_pspports pspirkeyb
 run_make -j `num_cpus`

--- a/scripts/pthreads-emb.sh
+++ b/scripts/pthreads-emb.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 wget --continue --no-check-certificate https://github.com/take-cheeze/pthreads-emb/tarball/master -O pthreads-emb-1.0.tar.gz
 rm -Rf pthreads-emb-1.0 && mkdir pthreads-emb-1.0 && tar --strip-components=1 --directory=pthreads-emb-1.0 -xvzf pthreads-emb-1.0.tar.gz
 cd pthreads-emb-1.0

--- a/scripts/smpeg-psp.sh
+++ b/scripts/smpeg-psp.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 wget --continue --no-check-certificate https://github.com/fungos/smpeg-psp/tarball/master -O smpeg-psp.tar.gz
 rm -Rf smpeg-psp && mkdir smpeg-psp && tar --strip-components=1 --directory=smpeg-psp -xvzf smpeg-psp.tar.gz
 cd smpeg-psp

--- a/scripts/sqlite.sh
+++ b/scripts/sqlite.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 download_and_extract https://www.sqlite.org/src/tarball/26778480/SQLite-26778480.tar.gz SQLite-26778480
 apply_patch sqlite-3.7.3-PSP
 mkdir build-ppu && cd build-ppu

--- a/scripts/squirrel.sh
+++ b/scripts/squirrel.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 download_and_extract http://sourceforge.net/projects/squirrel/files/squirrel_3_0_7_stable.tar.gz SQUIRREL3
 apply_patch squirrel-3.0.7
 AR="psp-ar" CC="psp-gcc" CXX="psp-g++" LIBS="-lc -lpspuser" make -j `num_cpus` -C squirrel sq32

--- a/scripts/zlib.sh
+++ b/scripts/zlib.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 ZLIB_VERSION=1.2.11
 
 download_and_extract http://sourceforge.net/projects/libpng/files/zlib/$ZLIB_VERSION/zlib-$ZLIB_VERSION.tar.gz zlib-$ZLIB_VERSION

--- a/scripts/zziplib.sh
+++ b/scripts/zziplib.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 test_deps_install zlib
 get_pspports zziplib
 run_configure


### PR DESCRIPTION
MinGW does not emulate the execute bit with file permissions but with file extensions and shebangs.

Without this change, line 44 `if [ -x $f ]; then` was failing.