### PR TITLE
CMake targets don't like MinGW

### DIFF
--- a/libraries.sh
+++ b/libraries.sh
@@ -4,6 +4,15 @@
  unset CC
  unset CXX
 
+
+ if [ "$(uname -o)" == "Msys" ]; then
+	 mv $PSPDEV/bin/psp-gcc.exe $PSPDEV/bin/psp-gcc
+	 mv $PSPDEV/bin/psp-g++.exe $PSPDEV/bin/psp-g++
+
+	 cp $PSPDEV/bin/psp-gcc $PSPDEV/bin/psp-gcc.exe
+	 cp $PSPDEV/bin/psp-g++ $PSPDEV/bin/psp-g++.exe
+ fi
+
  ## Set executable name for libtoolize
  if [ "$(uname)" == "Darwin" ]; then
      LIBTOOLIZE=glibtoolize


### PR DESCRIPTION
This issue is more random than ever, thus by even version of it with and without extension prevents it all together.

It needs to be 2 steps because by default msys `cp` doesn't allow to remove the extension.